### PR TITLE
Update data model and re-enable coil current display.

### DIFF
--- a/stellarator-navigator/README.md
+++ b/stellarator-navigator/README.md
@@ -14,29 +14,36 @@ uses the following procedure.
 ### Modify Code to Account for New Data
 
 - If there are substantial modifications to the underlying data model, account for them with code changes.
-- Addition or reclassification of new fields within Stellarator Records can be accommodated by:
+- Addition or reclassification of new fields within Stellarator Records can be accommodated by the following.
   - In `Types.ts`:
-    - Adding new fields and descriptions to the `StellaratorRecord` type in `Types.ts`
-    - Adding corresponding fields and ranges to the `FilterSettings` type in `Types.ts`
-  - In `Defaults.ts`:
-    - Ensure the new field is present with a sensible deafult in `defaultEmptyRecord`
+    - Add new fields and descriptions to the `StellaratorRecord` type in `Types.ts`
+    - Add corresponding fields and ranges to the `FilterSettings` type in `Types.ts`
   - In `DataDictionary.ts`:
-    - Adding new fields to the `KnownFields` enum
-    - Adding the new `KnownFields` entries to `DependentVariables`, `IndependentVariables` as appropriate
+    - Add new fields to the `KnownFields` enum
+    - Add the new `KnownFields` entries to `DependentVariables`, `IndependentVariables` as appropriate
     (These determine which field options are allowed for the x- and y-axis value selection in browsing plots)
-    - Adding the new `KnownFields` to `ToggleableVariables`, `RangeVariables`, `TripartiteVariables` as appropriate
+    - Add the new `KnownFields` to `ToggleableVariables`, `RangeVariables`, `TripartiteVariables` as appropriate
     (These determine the type of controls that will be created for filtering: Toggleable are checkbox lists,
-    Ranges are selected ranges, and Tripartite are categorical fields where we can display option 1, option 2, or both)
+    Ranges are range selectors, and Tripartite are categorical fields where we can display option 1, option 2, or both)
     - If there is a discrete set of valid values for the new data field, add a new entry along the lines of
     `meanIotaValidValues` or other examples
     - Add a full description of each new field in the `Fields` object
     - Add the new `KnownFields` entry to `CategoricalIndexedFields` if appropriate (these are used for creating
     indexes for the in-memory database)
-  - In `Database.ts`:
+  - In `Defaults.ts`:
+    - Ensure the new field is present with a sensible deafult in `defaultEmptyRecord`
+    - If the new field is a categorical indexed field, add it to the `categoricalIndexes` of the `initialDatabase`
+  - In `database.ts`:
     - Add the new field with its native (in-export) name in the `RawFields` enum
     - Add the new field in the appropriate location in `recordJig` and ensure the `order` fields are correct
+    - If the new field is a categorical index field, add a set for it to the `categoricalFieldIndexes` variable so
+      its records can be populated appropriately
   - In `SnTable.tsx`:
-    - Ensure the new field has been added appropriately to the `rows` variable mapped from each filtered record
+    - Ensure the new field has been added appropriately to the `rows` variable (mapped from each filtered record)
+  - In `RecordManifest.tsx`:
+    - Ensure the new field appears in the complete record values display (if desired)
+  - In `process_db.py`:
+    - Ensure database processing script has an up-to-date list of fields to drop and to log-scale
 - More complex changes (or applying this tool to a new data set) may require more extensive code updates and are
   beyond the scope of this readme.
 

--- a/stellarator-navigator/README.md
+++ b/stellarator-navigator/README.md
@@ -17,7 +17,9 @@ uses the following procedure.
 - Addition or reclassification of new fields within Stellarator Records can be accommodated by:
   - In `Types.ts`:
     - Adding new fields and descriptions to the `StellaratorRecord` type in `Types.ts`
-    - Adding corresponding ranges to the `FilterSettings` type in `Types.ts`
+    - Adding corresponding fields and ranges to the `FilterSettings` type in `Types.ts`
+  - In `Defaults.ts`:
+    - Ensure the new field is present with a sensible deafult in `defaultEmptyRecord`
   - In `DataDictionary.ts`:
     - Adding new fields to the `KnownFields` enum
     - Adding the new `KnownFields` entries to `DependentVariables`, `IndependentVariables` as appropriate
@@ -30,6 +32,11 @@ uses the following procedure.
     - Add a full description of each new field in the `Fields` object
     - Add the new `KnownFields` entry to `CategoricalIndexedFields` if appropriate (these are used for creating
     indexes for the in-memory database)
+  - In `Database.ts`:
+    - Add the new field with its native (in-export) name in the `RawFields` enum
+    - Add the new field in the appropriate location in `recordJig` and ensure the `order` fields are correct
+  - In `SnTable.tsx`:
+    - Ensure the new field has been added appropriately to the `rows` variable mapped from each filtered record
 - More complex changes (or applying this tool to a new data set) may require more extensive code updates and are
   beyond the scope of this readme.
 

--- a/stellarator-navigator/setup/check_files.py
+++ b/stellarator-navigator/setup/check_files.py
@@ -1,0 +1,43 @@
+
+
+# Responds to issue #2, confirming that every ID in the database has an associated
+# file for curves, surfaces, modb, and axis.
+
+# Note that after running process_files.py, most of these (axis not yet supported)
+# will have been reformatted and be .json rather than .txt.
+
+# Note also you could probably do this with capturing the output of a find command
+# and sorting & comparing the resulting list, but this feels less hacky.
+
+# Another alternative would be to walk the records/ directory, but we already
+# have the full IDs list from the database export.
+
+import pickle
+import os
+
+id_length = 7
+prefix_length = 4
+
+database_name = 'QUASR.pkl'
+with open(database_name, "rb") as file:
+    data = pickle.load(file)
+
+ids = data["ID"]
+
+#   Patterns:
+# axis: graphics/axis/{PREFIX}/axis{ID}.txt
+# surfaces: graphics/surfaces/{PREFIX}/surfaces{ID}.[txt | json]
+# modb: graphics/modB/{PREFIX}/modB{ID}.txt
+# curves: graphics/curves/{PREFIX}/curves{ID}.[txt | json]
+# currents: NOT ALWAYS SUPPORTED?
+
+typenames = ['axis', 'surfaces', 'modB', 'curves']
+filetype_suffix = "txt"
+
+for id in ids:
+    name = str(id).rjust(id_length, "0")
+    prename = name[:prefix_length]
+    for filetype in typenames:
+        expected_data = os.path.join("graphics", filetype, prename, f"{filetype}{name}.{filetype_suffix}")
+        if not os.path.exists(expected_data):
+            print(f"Missing data--record {id} lacks {filetype} record {expected_data}")

--- a/stellarator-navigator/src/components/display/SnTable.tsx
+++ b/stellarator-navigator/src/components/display/SnTable.tsx
@@ -1,7 +1,7 @@
 import { DataGrid, GridColDef, GridRowSelectionModel } from '@mui/x-data-grid'
 import { plotGridInternalMargin } from '@snComponents/Overview'
 import { filterTo } from '@snState/filter'
-import { Fields, KnownFields, ToggleableVariables } from '@snTypes/DataDictionary'
+import { Fields, KnownFields, ToggleableVariables, helicityValuesTranslation } from '@snTypes/DataDictionary'
 import { StellaratorRecord } from '@snTypes/Types'
 import { FunctionComponent } from 'react'
 import OpenSelectedButton from './OpenSelected'
@@ -73,13 +73,13 @@ const SnTable: FunctionComponent<SnTableProps> = (props: SnTableProps) => {
             maxMeanSquaredCurve: r.maxMeanSquaredCurve.toFixed(5),
             minIntercoilDist: r.minIntercoilDist.toFixed(5),
             qaError: (10 ** r.qaError).toExponential(4),
-            gradient: (10 ** r.gradient).toExponential(4),
             aspectRatio: r.aspectRatio.toFixed(1),
             minorRadius: r.minorRadius.toFixed(3),
             volume: r.volume.toFixed(5),
             minCoil2SurfaceDist: r.minCoil2SurfaceDist.toFixed(5),
             meanElongation: r.meanElongation.toFixed(4),
             maxElongation: r.maxElongation.toFixed(4),
+            helicity: helicityValuesTranslation[r.helicity] // TODO: standardize this better?
         }
     })
 

--- a/stellarator-navigator/src/components/display/visualizer/RecordManifest.tsx
+++ b/stellarator-navigator/src/components/display/visualizer/RecordManifest.tsx
@@ -1,4 +1,4 @@
-import { getLabel } from "@snTypes/DataDictionary"
+import { getLabel, helicityValuesTranslation } from "@snTypes/DataDictionary"
 import { StellaratorRecord } from "@snTypes/Types"
 import { FunctionComponent } from "react"
 
@@ -79,13 +79,18 @@ const RecordManifest: FunctionComponent<recordProps> = (props: recordProps) => {
             <span className="manifestLabel">{getLabel({name: "surfaceTypes", labelType: "full"})}:</span>
             <span>{rec.surfaceTypes.join(", ")}</span>
         </div> */}
-        <div key="gradient">
+        {/* Gradient removed as of 2024.01 export */}
+        {/* <div key="gradient">
             <span className="manifestLabel">{getLabel({name: "gradient", labelType: "full"})}:</span>
             <span>{(10 ** rec.gradient).toExponential(10)}</span>
-        </div>
+        </div> */}
         <div key="aspectRatio">
             <span className="manifestLabel">{getLabel({name: "aspectRatio", labelType: "full"})}:</span>
             <span>{rec.aspectRatio}</span>
+        </div>
+        <div key="helicity">
+            <span className="manifestLabel">{getLabel({name: "helicity", labelType: "full"})}:</span>
+            <span>{helicityValuesTranslation[rec.helicity]}</span>
         </div>
     </div>)
 }

--- a/stellarator-navigator/src/components/display/visualizer/SurfaceControls.tsx
+++ b/stellarator-navigator/src/components/display/visualizer/SurfaceControls.tsx
@@ -18,7 +18,7 @@ type ModelProps = {
 }
 
 const Model: FunctionComponent<ModelProps> = (props: ModelProps) => {
-    const { checksNeeded, surfaceChecks, setSurfaceChecks, colorMap, setColorMap, showFullRing, setShowFullRing } = props
+    const { checksNeeded, surfaceChecks, setSurfaceChecks, showCurrents, setShowCurrents, colorMap, setColorMap, showFullRing, setShowFullRing } = props
 
     const handleCheckboxChange = useCallback((index: number, newState: boolean) => {
         if (index === -1) {
@@ -60,13 +60,12 @@ const Model: FunctionComponent<ModelProps> = (props: ModelProps) => {
                     />
                 </div>
                 <div className="surfaceControlFlexSplit">
-                    {/* TODO: TEMPORARILY DISABLED while a data irregularity is updated */}
-                    {/* <SnSwitch
+                    <SnSwitch
                         header="Coil currents"
                         label="Color coils per currents?"
                         checked={showCurrents}
                         handleChange={setShowCurrents}
-                    /> */}
+                    />
                 </div>
             </div>
         </>

--- a/stellarator-navigator/src/components/selectionControl/TripartDropdownSelector.tsx
+++ b/stellarator-navigator/src/components/selectionControl/TripartDropdownSelector.tsx
@@ -1,6 +1,6 @@
 
 import { FormControl, MenuItem, Select, SelectChangeEvent, Typography } from "@mui/material"
-import { Fields, TripartiteVariables, getLabel } from "@snTypes/DataDictionary"
+import { Fields, TripartiteVariables, getFieldValueDescriptions, getLabel } from "@snTypes/DataDictionary"
 import { FunctionComponent, useCallback } from "react"
 import { defaultTripartiteBothState } from "./SelectionControlCallbacks"
 
@@ -14,7 +14,8 @@ type Props = {
 const TripartDropdownSelector: FunctionComponent<Props> = (props: Props) => {
     const { field, value, onChange } = props
     const vals = (Fields[field].values) ?? []
-    const labels = vals
+    // TODO: Make this more rigorous
+    const labels = getFieldValueDescriptions(field)
     const cb = useCallback((evt: SelectChangeEvent<number>) => onChange(field, evt), [field, onChange])
 
     const bothItem = <MenuItem key={-1} value={defaultTripartiteBothState}>Any</MenuItem>

--- a/stellarator-navigator/src/constants/DataDictionary.ts
+++ b/stellarator-navigator/src/constants/DataDictionary.ts
@@ -15,7 +15,7 @@ export enum KnownFields {
     MAX_MEAN_SQUARED_CURVE = 'maxMeanSquaredCurve',
     MIN_INTERCOIL_DIST = 'minIntercoilDist',
     QA_ERROR = 'qaError',
-    GRADIENT = 'gradient',
+    // GRADIENT = 'gradient',   // Removed as of 2024.01 export
     ASPECT_RATIO = 'aspectRatio',
     MINOR_RADIUS = 'minorRadius',
     VOLUME = 'volume',
@@ -26,6 +26,7 @@ export enum KnownFields {
     IOTA_PROFILE = 'iotaProfile',
     TF_PROFILE = 'tfProfile',
     SURFACE_TYPES = 'surfaceTypes',
+    HELICITY = 'helicity',
 }
 
 export enum DependentVariables {
@@ -68,7 +69,7 @@ export enum ToggleableVariables {
     NC_PER_HP = KnownFields.NC_PER_HP,
     NFP = KnownFields.NFP,
     MEAN_IOTA = KnownFields.MEAN_IOTA,
-    N_SURFACES = KnownFields.NSURFACES
+    N_SURFACES = KnownFields.NSURFACES,
 }
 
 export enum RangeVariables {
@@ -83,11 +84,12 @@ export enum RangeVariables {
     VOLUME = KnownFields.VOLUME,
     MIN_COIL_TO_SURFACE_DIST = KnownFields.MIN_COIL_TO_SURFACE_DIST,
     MEAN_ELONGATION = KnownFields.MEAN_ELONGATION,
-    MAX_ELONGATION = KnownFields.MAX_ELONGATION
+    MAX_ELONGATION = KnownFields.MAX_ELONGATION,
 }
 
 export enum TripartiteVariables {
     N_FOURIER_COIL = KnownFields.N_FOURIER_COIL,
+    HELICITY = KnownFields.HELICITY,
 }
 
 export const dependentVariableDropdownConfig: { key: number, value: DependentVariables }[] = [
@@ -192,7 +194,9 @@ export const totalCoilLengthValidValues = [
 ]
 
 export const meanIotaValidValues = [
-    0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9
+    0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
+    1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
+    2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
 ]
 
 export const ncPerHpValidValues = [
@@ -204,6 +208,10 @@ export const nfpValidValues = [
 ]
 
 export const nFourierCoilValidValues = [6, 16]
+
+export const helicityValidValues = [0, 1] // 0 = QA, 1 = QH
+// The below is a hack, and we should do something more principled.
+export const helicityValuesTranslation = ['QA', 'QH']
 
 export const nSurfacesValidValues = [
     1, 2, 3, 4, 5, 6, 7
@@ -244,7 +252,7 @@ export const Fields: FieldRecords = {
         fullLabel: "Device ID",
         description: "Unique identifier of the design simulation",
         unit: undefined,
-        range: [952, 504819],
+        range: [952, 1968351],
         isLog: false,
         isCategorical: true,
         markedValue: undefined,
@@ -286,7 +294,7 @@ export const Fields: FieldRecords = {
         fullLabel: "Mean Iota",
         description: "The mean pitch of a particle trajectory across the surface",
         unit: undefined,
-        range: [0.1, 0.9],
+        range: [0.1, 2.6],
         values: meanIotaValidValues,
         isLog: false,
         isCategorical: true,
@@ -353,7 +361,7 @@ export const Fields: FieldRecords = {
         fullLabel: "Max curvature (kappa)",
         description: "Maximum curvature in the coils of the device",
         unit: `1/${METER_UNIT}`,
-        range: [1.6, 5.005],
+        range: [1.6, 19.55],
         isLog: false,
         isCategorical: false,
         markedValue: 5,
@@ -366,7 +374,7 @@ export const Fields: FieldRecords = {
         fullLabel: "Max mean-squared curvature",
         description: "Maximum mean squared curvature of the coils",
         unit: `1/${METER_UNIT}^2`,
-        range: [1.05, 5.005],
+        range: [1.05, 35.05],
         isLog: false,
         isCategorical: false,
         markedValue: 5,
@@ -391,29 +399,29 @@ export const Fields: FieldRecords = {
         plotLabel: "Root of QA Error",
         fullLabel: "Root of Quasi-Axisymmetry (QA) Error",
         description: "Square root of quasi-Axisymmetry (QA) error, proxy for particle loss",
-        range: [-5.47, -0.535],
+        range: [-5.47, -0.44],
         isLog: true,
         isCategorical: false,
         markedValue: -4.30,
         markedValueDesc: "Marked line indicates the Earth's background magnetic field.",
         displayInTable: true
     },
-    'gradient': {
-        shortLabel: "Gradient",
-        plotLabel: "Gradient",
-        fullLabel: "Optimization gradient",
-        description: "Norm of the gradient at the final iteration of the optimization algorithm--an indicator of closeness to optimality",
-        range: [-12.74, 12.12],
-        isLog: true,
-        isCategorical: false,
-        displayInTable: true
-    },
+    // 'gradient': {
+    //     shortLabel: "Gradient",
+    //     plotLabel: "Gradient",
+    //     fullLabel: "Optimization gradient",
+    //     description: "Norm of the gradient at the final iteration of the optimization algorithm--an indicator of closeness to optimality",
+    //     range: [-12.74, 12.12],
+    //     isLog: true,
+    //     isCategorical: false,
+    //     displayInTable: true
+    // },
     'aspectRatio': {
         shortLabel: "AR",
         plotLabel: "Aspect ratio",
         fullLabel: "Aspect ratio (AR)",
         description: "The aspect ratio of the device, computed using the VMEC definition",
-        range: [2.5, 20.03],
+        range: [2.5, 24.05],
         isLog: false,
         isCategorical: false,   // technically not categorical, but for our display purposes, might as well be
         tableColumnWidth: 30,
@@ -425,7 +433,7 @@ export const Fields: FieldRecords = {
         fullLabel: "Minor radius",
         description: "The minor radius of the outermost surface, scaled so the major radius is 1",
         unit: METER_UNIT,
-        range: [0.04996, 0.363],
+        range: [0.0416, 0.363],
         isLog: false,
         isCategorical: false,
         displayInTable: true
@@ -436,7 +444,7 @@ export const Fields: FieldRecords = {
         fullLabel: "Volume",
         description: "Volume enclosed by the outermost toroidal surface over which quasiasymmetry was optimized",
         unit: `${METER_UNIT}^3`,
-        range: [0.049, 2.42],
+        range: [0.034, 2.42],
         isLog: false,
         isCategorical: false,
         displayInTable: true
@@ -447,7 +455,7 @@ export const Fields: FieldRecords = {
         fullLabel: "Min coil-surface distance",
         description: "Minimumn distance between any device coil and the outermost surface over which quasiasymmetry was optimized",
         unit: METER_UNIT,
-        range: [0.0999, 0.61],
+        range: [0.0999, 0.685],
         isLog: false,
         isCategorical: false,
         markedValue: 0.1,
@@ -459,7 +467,7 @@ export const Fields: FieldRecords = {
         plotLabel: "Mean Elongation",
         fullLabel: "Mean Elongation (elliptical axis ratio)",
         description: "Ratio of major to minor axis of an ellipse fitted to an innermost magnetic surface (mean)",
-        range: [1, 44],
+        range: [1, 62],
         isLog: false,
         isCategorical: false,
         // markedValue?: undefined,
@@ -470,7 +478,7 @@ export const Fields: FieldRecords = {
         plotLabel: "Max Elongation",
         fullLabel: "Max Elongation (elliptical axis ratio)",
         description: "Maximum ratio of major to m inor axis of an ellipse fitted to an innermost magnetic surface",
-        range: [1, 146],
+        range: [1.1, 313.2],
         isLog: false,
         isCategorical: false,
         // markedValue?: undefined,
@@ -519,6 +527,19 @@ export const Fields: FieldRecords = {
         isCategorical: false,
         tableColumnWidth: 0,
         displayInTable: false
+    },
+    'helicity': {
+        shortLabel: "Helicity",
+        plotLabel: "Helicity",
+        fullLabel: "Helicity",
+        description: "Quasi-axisymmetric (QA) or Quasi-helically symmetric (QH)",
+        range: [0, 1],
+        values: helicityValidValues,
+        isLog: false,
+        isCategorical: true,
+        markedValue: undefined,
+        tableColumnWidth: 80,
+        displayInTable: true
     }
 }
 
@@ -534,12 +555,21 @@ export const fieldMarkedValueDesc = (fieldName?: string): string | undefined => 
     Fields[fieldName as KnownFields]?.markedValueDesc
 )
 
+export const getFieldValueDescriptions = (fieldName: TripartiteVariables): string[] | number[] => {
+    if (fieldName === TripartiteVariables.HELICITY) {
+        return helicityValuesTranslation
+    }
+    return Fields[fieldName]?.values ?? []
+}
+
+
 export enum CategoricalIndexedFields {
     MEAN_IOTA = 'meanIota',
     NC_PER_HP = 'ncPerHp',
     NFP = 'nfp',
     NFOURIER = 'nFourierCoil',
-    NSURFACES = 'nSurfaces'
+    NSURFACES = 'nSurfaces',
+    HELICITY = 'helicity',
 }
 
 export enum KnownPathType {

--- a/stellarator-navigator/src/constants/Defaults.ts
+++ b/stellarator-navigator/src/constants/Defaults.ts
@@ -45,7 +45,8 @@ export const initialDatabase: NavigatorDatabase = {
         [ CategoricalIndexedFields.NC_PER_HP ]: {},
         [ CategoricalIndexedFields.NFP       ]: {},
         [ CategoricalIndexedFields.NFOURIER  ]: {},
-        [ CategoricalIndexedFields.NSURFACES ]: {}
+        [ CategoricalIndexedFields.NSURFACES ]: {},
+        [ CategoricalIndexedFields.HELICITY  ]: {}
     },
     allIdSet: new Set<number>([])
 }
@@ -64,7 +65,6 @@ export const defaultEmptyRecord: StellaratorRecord = {
     maxMeanSquaredCurve: 0,
     minIntercoilDist: 0,
     qaError: 0,
-    gradient: 0,
     aspectRatio: 0,
     minorRadius: 0,
     volume: 0,
@@ -74,5 +74,6 @@ export const defaultEmptyRecord: StellaratorRecord = {
     message: "",
     iotaProfile: [],
     tfProfile: [],
-    surfaceTypes: []
+    surfaceTypes: [],
+    helicity: 0
 }

--- a/stellarator-navigator/src/logic/database.ts
+++ b/stellarator-navigator/src/logic/database.ts
@@ -10,29 +10,30 @@ export type RawData = {
 }
 
 export enum RawFields {
-    ID                     = 'ID',
-    COIL_LENGTH_PER_HP     = 'coil_length_per_hp',
-    TOTAL_COIL_LENGTH      = 'total_coil_length',
-    MEAN_IOTA              = 'mean_iota',
-    NC_PER_HP              = 'nc_per_hp',
-    NFP                    = 'nfp',
-    N_FOURIER_COIL         = 'Nfourier_coil',
-    NSURFACES              = 'Nsurfaces',
-    MAX_KAPPA              = 'max_kappa',
-    MAX_MEAN_SQUARED_CURVE = 'max_msc',
-    MIN_INTERCOIL_DIST     = 'min_coil2coil_dist',
-    QA_ERROR               = 'qa_error',
-    GRADIENT               = 'gradient',
-    ASPECT_RATIO           = 'aspect_ratio',
-    MINOR_RADIUS           = 'minor_radius',
-    VOLUME                 = 'volume',
+    ID                       = 'ID',
+    COIL_LENGTH_PER_HP       = 'coil_length_per_hp',
+    TOTAL_COIL_LENGTH        = 'total_coil_length',
+    MEAN_IOTA                = 'mean_iota',
+    NC_PER_HP                = 'nc_per_hp',
+    NFP                      = 'nfp',
+    N_FOURIER_COIL           = 'Nfourier_coil',
+    NSURFACES                = 'Nsurfaces',
+    MAX_KAPPA                = 'max_kappa',
+    MAX_MEAN_SQUARED_CURVE   = 'max_msc',
+    MIN_INTERCOIL_DIST       = 'min_coil2coil_dist',
+    QA_ERROR                 = 'qa_error',
+    // GRADIENT                 = 'gradient',   // removed in 2024.01 export
+    ASPECT_RATIO             = 'aspect_ratio',
+    MINOR_RADIUS             = 'minor_radius',
+    VOLUME                   = 'volume',
     MIN_COIL_TO_SURFACE_DIST = 'min_coil2surface_dist',
-    MEAN_ELONGATION        = 'mean_elongation',
-    MAX_ELONGATION         = 'max_elongation',
-    MESSAGE                = 'message',       // one of "Naive, fine scan", "Naive, global scan", "TuRBO, fine scan", "TuRBO, global scan"
-    IOTA_PROFILE           = 'iota_profile',  // array of nSurfaces+1 numbers
-    TF_PROFILE             = 'tf_profile',    // array of nSurfaces+1 numbers
-    SURFACE_TYPES          = 'surface_types', // array of nSurfaces + 1 length, each element's values one of "exact", "ls"
+    MEAN_ELONGATION          = 'mean_elongation',
+    MAX_ELONGATION           = 'max_elongation',
+    MESSAGE                  = 'message',       // one of "Naive, fine scan", "Naive, global scan", "TuRBO, fine scan", "TuRBO, global scan"
+    IOTA_PROFILE             = 'iota_profile',  // array of nSurfaces+1 numbers
+    TF_PROFILE               = 'tf_profile',    // array of nSurfaces+1 numbers. No longer used as of 2024.01 export.
+    SURFACE_TYPES            = 'surface_types', // array of nSurfaces + 1 length, each element's values one of "exact", "ls"
+    HELICITY                 = 'helicity',      // 1 or 0: 1 for quasi-helically symmetry, 0 for quasi-axisymmetric (the original)
 }
 
 export type rawObject = {[key in RawFields]: fieldType}
@@ -41,7 +42,7 @@ type jigRow = { raw: RawFields, order: number, objectField: KnownFields }
 
 // It's easier, and probably not even any brittler, to just ignore the column names listed in the json file
 // and use the known values for the column names directly. But, when we pull individual records,
-// it's more reliable to match up the field names. The recordJig creates a matching between the two sets.
+// it's more reliable to match up the field names. The recordJig creates a mapping between the two sets.
 
 const recordJig: jigRow[] = [
     { raw: RawFields.QA_ERROR,                 order:  0, objectField: KnownFields.QA_ERROR                 },
@@ -53,20 +54,21 @@ const recordJig: jigRow[] = [
     { raw: RawFields.MIN_INTERCOIL_DIST,       order:  6, objectField: KnownFields.MIN_INTERCOIL_DIST       },
     { raw: RawFields.NC_PER_HP,                order:  7, objectField: KnownFields.NC_PER_HP                },
     { raw: RawFields.NFP,                      order:  8, objectField: KnownFields.NFP                      },
-    { raw: RawFields.GRADIENT,                 order:  9, objectField: KnownFields.GRADIENT                 },
-    { raw: RawFields.ASPECT_RATIO,             order: 10, objectField: KnownFields.ASPECT_RATIO             },
-    { raw: RawFields.ID,                       order: 11, objectField: KnownFields.ID                       },
-    { raw: RawFields.MINOR_RADIUS,             order: 12, objectField: KnownFields.MINOR_RADIUS             },
-    { raw: RawFields.N_FOURIER_COIL,           order: 13, objectField: KnownFields.N_FOURIER_COIL           },
-    { raw: RawFields.NSURFACES,                order: 14, objectField: KnownFields.NSURFACES                },
-    { raw: RawFields.VOLUME,                   order: 15, objectField: KnownFields.VOLUME                   },
-    { raw: RawFields.MIN_COIL_TO_SURFACE_DIST, order: 16, objectField: KnownFields.MIN_COIL_TO_SURFACE_DIST },
-    { raw: RawFields.MEAN_ELONGATION,          order: 17, objectField: KnownFields.MEAN_ELONGATION          },
-    { raw: RawFields.MAX_ELONGATION,           order: 18, objectField: KnownFields.MAX_ELONGATION           },
-    { raw: RawFields.MESSAGE,                  order: 19, objectField: KnownFields.MESSAGE                  },
-    { raw: RawFields.IOTA_PROFILE,             order: 20, objectField: KnownFields.IOTA_PROFILE             },
-    { raw: RawFields.TF_PROFILE,               order: 21, objectField: KnownFields.TF_PROFILE               },
-    { raw: RawFields.SURFACE_TYPES,            order: 22, objectField: KnownFields.SURFACE_TYPES            },
+    // { raw: RawFields.GRADIENT,                 order:  9, objectField: KnownFields.GRADIENT                 }, // REMOVED in 2024.01 export
+    { raw: RawFields.ASPECT_RATIO,             order:  9, objectField: KnownFields.ASPECT_RATIO             },
+    { raw: RawFields.ID,                       order: 10, objectField: KnownFields.ID                       },
+    { raw: RawFields.MINOR_RADIUS,             order: 11, objectField: KnownFields.MINOR_RADIUS             },
+    { raw: RawFields.N_FOURIER_COIL,           order: 12, objectField: KnownFields.N_FOURIER_COIL           },
+    { raw: RawFields.NSURFACES,                order: 13, objectField: KnownFields.NSURFACES                },
+    { raw: RawFields.VOLUME,                   order: 14, objectField: KnownFields.VOLUME                   },
+    { raw: RawFields.MIN_COIL_TO_SURFACE_DIST, order: 15, objectField: KnownFields.MIN_COIL_TO_SURFACE_DIST },
+    { raw: RawFields.MEAN_ELONGATION,          order: 16, objectField: KnownFields.MEAN_ELONGATION          },
+    { raw: RawFields.MAX_ELONGATION,           order: 17, objectField: KnownFields.MAX_ELONGATION           },
+    { raw: RawFields.MESSAGE,                  order: 18, objectField: KnownFields.MESSAGE                  },
+    { raw: RawFields.IOTA_PROFILE,             order: 19, objectField: KnownFields.IOTA_PROFILE             },
+    { raw: RawFields.TF_PROFILE,               order: 20, objectField: KnownFields.TF_PROFILE               },
+    { raw: RawFields.SURFACE_TYPES,            order: 21, objectField: KnownFields.SURFACE_TYPES            },
+    { raw: RawFields.HELICITY,                 order: 22, objectField: KnownFields.HELICITY                 },
 ]
 
 export const makeRecordFromObject = (rawRecord: rawObject): StellaratorRecord => {
@@ -96,7 +98,8 @@ export const makeDatabase = (rawData: RawData) => {
         'ncPerHp': {},
         'nfp': {},
         'nFourierCoil': {},
-        'nSurfaces': {}
+        'nSurfaces': {},
+        'helicity': {}
     }
 
     const categoricalFields = Object.keys(categoricalFieldIndexes) as CategoricalIndexedFields[]

--- a/stellarator-navigator/src/pages/About.tsx
+++ b/stellarator-navigator/src/pages/About.tsx
@@ -76,7 +76,7 @@ const Home: FunctionComponent<Props> = (props: Props) => {
                 </div>
                 <div className="homeCopy">
                     <div>
-                        The QUASR repository contains a database of almost 140,000 curl-free stellarators
+                        The QUASR repository contains a database of over 320,000 curl-free stellarators
                         and the coil sets that generate them, optimized for volume quasi-symmetry.
                     </div>
                     <div>

--- a/stellarator-navigator/src/pages/Model.tsx
+++ b/stellarator-navigator/src/pages/Model.tsx
@@ -24,8 +24,7 @@ const Model: FunctionComponent = () => {
     const [instructionsOpen, setInstructionsOpen] = useState(false)
     const [colorMap, setColorMap] = useState<SupportedColorMap>(SupportedColorMap.PLASMA)
     const [showFullRing, setShowFullRing] = useState<boolean>(false)
-    // TODO: Temporarily defaulted to False & disabled control while an irregularity in the data is updated
-    const [showCurrents, setShowCurrents] = useState<boolean>(false)
+    const [showCurrents, setShowCurrents] = useState<boolean>(true)
     const [surfaceChecks, setSurfaceChecks] = useState<boolean[]>(Array(rec.nSurfaces).fill(true))
     useEffect(() => setSurfaceChecks(Array<boolean>(rec.nSurfaces).fill(true)), [rec.nSurfaces])
 

--- a/stellarator-navigator/src/types/Types.ts
+++ b/stellarator-navigator/src/types/Types.ts
@@ -20,6 +20,7 @@ export type FilterSettings = {
     meanElongation: number[]
     maxElongation: number[]
     nFourierCoil?: number
+    helicity?: number
     dependentVariable: DependentVariables
     independentVariable: IndependentVariables
     coarsePlotSplit?: ToggleableVariables
@@ -39,30 +40,31 @@ export type FilterSettings = {
 // See also the further explanations/notes in DataDictionary.ts
 export type StellaratorRecord = {
     // PK
-    id: number,                     // 952 - 504819
+    id: number,                     // 952 - 1,968,351. 7 digits.
     // Categorical fields
     // Note: coil lengths are technically categorical but we mark them as continuous in the the
     // data dictionary because there's like 80 possible values
     coilLengthPerHp: number,        // range 4.5-60. Length of coil used per half-period (meters)
     totalCoilLength: number,        // range 28.5 - 120. Total length of coil used to construct coils (m)
-    meanIota: number,               // range 0.1 - 0.9
+    meanIota: number,               // range 0.1 - 2.6
     ncPerHp: number,                // range 1-13, coil count per half-period
     nfp: number,                    // range 1-5, field period count
     nFourierCoil: number,           // 6 or 16. (Number of Fourier modes used in coil simulation)
+    helicity: number,               // 0 or 1. 0: QA--Quasiaxisymmetric (original); 1: QH--quasi-helically symmetric (devices added post-2024.01)
     nSurfaces: number,              // # of surfaces over which QA was optimized. (1-7). Shld correspond to surface data.
     // Globally unique(ish)/continuous fields
-    maxKappa: number,               // range 1.6 - 5.005, max curvature
-    maxMeanSquaredCurve: number,    // range 1.05 - 5.005, ??
+    maxKappa: number,               // range 1.6 - 19.55, max curvature
+    maxMeanSquaredCurve: number,    // range 1.05 - 35.05, ??
     minIntercoilDist: number,       // range epsilon-below-0.09 - 0.4, minimum distance between coils
     qaError: number,                // stored in log10, -10.94 to -1.07, quasiasymmetry error (no unit)
-    gradient: number,               // stored in log10, -12.74 to +12.12, arbitrary convergence measure (no unit)
-    aspectRatio: number,            // range 2.5 - 20.03 (no unit)
-    minorRadius: number,            // range 0.04996 - 0.363 (M). Minor radius of outermost surface ("minor radius")
+    // gradient: number,               // stored in log10, -12.74 to +12.12, arbitrary convergence measure (no unit)  // removed as of 2024.01 export
+    aspectRatio: number,            // range 2.5 - 24.05 (no unit)
+    minorRadius: number,            // range 0.0416 - 0.363 (M). Minor radius of outermost surface ("minor radius")
                                     // Note somewhere that this is scaled so that major radius is always 1
-    volume: number,                 // range 0.049 - 2.42. Volume enclosed by outermost toroidal surface over which QA was optimized. (m^3)
-    minCoil2SurfaceDist: number,    // range [0.0999, 0.61]. min distance between coil and outermost optimization surface. (m)
-    meanElongation: number,         // range [1, 44]. 
-    maxElongation: number,          // range [1, 146].
+    volume: number,                 // range 0.034 - 2.42. Volume enclosed by outermost toroidal surface over which QA was optimized. (m^3)
+    minCoil2SurfaceDist: number,    // range [0.0999, 0.685]. min distance between coil and outermost optimization surface. (m)
+    meanElongation: number,         // range [1, 62]. 
+    maxElongation: number,          // range [1.1, 313.2].
     // Weird ones
     message: string,                // descriptor of analysis: as "[Naive | TuRBO], [global | fine] scan"
     iotaProfile: number[],          // array of nSurfaces+2 length, each element a rotational transform value (y-axis of iota profile plot)

--- a/stellarator-navigator/src/util/makeResourcePath.ts
+++ b/stellarator-navigator/src/util/makeResourcePath.ts
@@ -7,7 +7,8 @@ const basePath = BASENAME === '/'
                         ? 'http://localhost:5173/'
                         : 'https://quasr.flatironinstitute.org/'
                     : `https://users.flatironinstitute.org${BASENAME}/`
-const idLength = 6
+const idLength = 7
+const prefixLength = 4
 
 
 export type ValidId = { id: string }
@@ -19,7 +20,7 @@ const makeResourcePath = (validId: ValidId, type: KnownPathType) => {
     const { id } = validId
     const graphicsTypes = getEnumVals(GraphicsType)
     const graphicsPart = graphicsTypes.includes(type) ? 'graphics/' : ''
-    const binPrefix = id.substring(0, 3)
+    const binPrefix = id.substring(0, prefixLength)
 
     let typeDirectory = ''
     let fileBase = ''


### PR DESCRIPTION
This PR brings the code up to support for the January 2024 export of the QUASR database. The big change for this version is the addition of quasi-helically symmetric (basically, "not round") devices, and a separate variable to track this; the gradient has also been removed from the export (its information was difficult to interpret apart from purely as a means of monitoring the simulation algorithm).

Also, record IDs were increased to 7 characters and the data file organization now uses 4-character prefix directories; these changes have been reflected in the record- and file-processing scripts.

In general, this PR implements the procedure documented in the README for adding new fields, so I won't belabor the point too much for specific changes, but in addition to the above, I'll also call out that I updated the value ranges for the existing fields by checking against the database export.

Also, there is probably a need to provide more formal support for translating numeric "values" entries into descriptive ones. Right now this is kind of hacky; probably the best thing to do would be to add it to the `Fields` in the data dictionary. I'll open an additional issue for this.