### PR TITLE
Fix issue #28

### DIFF
--- a/stellarator-navigator/src/components/display/plots/plotFittings/PlotGridNotes.tsx
+++ b/stellarator-navigator/src/components/display/plots/plotFittings/PlotGridNotes.tsx
@@ -22,7 +22,7 @@ type OverallHitCountProps = {
 export const OverallHitCount: FunctionComponent<PropsWithChildren<OverallHitCountProps>> = (props: PropsWithChildren<OverallHitCountProps>) => (
     <div className="plotGridNote">
         {props.children}
-        <span className="plotGridNoteText">Current filter settings return {props.hits} devices.</span>
+        <span className="plotGridNoteText">Current filter settings return {props.hits} devices. Devices from the selected plot are shown below.</span>
     </div>
 )
 

--- a/stellarator-navigator/src/state/NavigatorReducer.ts
+++ b/stellarator-navigator/src/state/NavigatorReducer.ts
@@ -111,9 +111,9 @@ const applyUpdatedFilters = (settings: FilterSettings, ignoreSizeCheck: boolean 
 
 
 const selectedOrFirst = (field: ToggleableVariables, choices: boolean[], selected: number | undefined): number | undefined => {
-    if (selected === undefined) return selected
     const setVals = getValuesFromBoolArray(field, choices)
-    return setVals.includes(selected) ? selected : setVals[0]
+    if (setVals.length === 0) return undefined
+    return selected != undefined && setVals.includes(selected) ? selected : setVals[0]
 }
 
 


### PR DESCRIPTION
Fix issue #28 by tweaking the "focused plot rationalization" logic in `NavigatorReducer.tsx`. 

While I was around, I also changed the static text of the "Current settings return XXXX devices" message to include the statement that the devices from the selected plot are shown in the table below--actually displaying what that number is winds up being a good deal more complicated, and I should probably do a more thoroughgoing revision of how both data sets and plot-focus settings are handled in order to do a good job of reporting this with precision.